### PR TITLE
config and interface changes for the stretch robot

### DIFF
--- a/launch/giskardpy_stretch_iai.launch
+++ b/launch/giskardpy_stretch_iai.launch
@@ -1,0 +1,14 @@
+<launch>
+    <node pkg="giskardpy" type="stretch_trajectory.py" name="giskard" output="screen"/>
+
+    <node pkg="giskardpy" type="interactive_marker.py" name="giskard_interactive_marker" output="screen">
+        <rosparam param="enable_self_collision">False</rosparam>
+        <rosparam param="interactive_marker_chains">
+            - [base_link, camera_link]
+            - [map, base_link]
+            - [map, link_grasp_center]
+        </rosparam>
+    </node>
+
+
+</launch>

--- a/scripts/iai_robots/stretch/stretch_trajectory.py
+++ b/scripts/iai_robots/stretch/stretch_trajectory.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import rospy
+
+from giskardpy_ros.configs.behavior_tree_config import OpenLoopBTConfig
+from giskardpy_ros.configs.giskard import Giskard
+from giskardpy_ros.configs.iai_robots.stretch import StretchCollisionAvoidanceConfig, StretchTrajectoryInterface
+from giskardpy_ros.configs.iai_robots.tiago import TiagoCollisionAvoidanceConfig, TiagoStandaloneInterface
+from giskardpy.model.world_config import WorldWithDiffDriveRobot
+
+if __name__ == '__main__':
+    rospy.init_node('giskard')
+    giskard = Giskard(world_config=WorldWithDiffDriveRobot(urdf=rospy.get_param('robot_description')),
+                      collision_avoidance_config=StretchCollisionAvoidanceConfig(),
+                      robot_interface_config=StretchTrajectoryInterface(),
+                      behavior_tree_config=OpenLoopBTConfig(debug_mode=True),
+                      )
+    giskard.live()

--- a/src/giskardpy_ros/configs/iai_robots/stretch.py
+++ b/src/giskardpy_ros/configs/iai_robots/stretch.py
@@ -1,5 +1,5 @@
 from giskardpy.model.collision_avoidance_config import CollisionAvoidanceConfig
-from giskardpy_ros.configs.robot_interface_config import StandAloneRobotInterfaceConfig
+from giskardpy_ros.configs.robot_interface_config import StandAloneRobotInterfaceConfig, RobotInterfaceConfig
 
 
 class StretchCollisionAvoidanceConfig(CollisionAvoidanceConfig):
@@ -33,3 +33,41 @@ class StretchStandaloneInterface(StandAloneRobotInterfaceConfig):
             'joint_head_pan',
             'joint_head_tilt',
         ])
+
+class StretchTrajectoryInterface(RobotInterfaceConfig):
+
+    def __init__(self,
+                 map_name: str = 'map',
+                 localization_joint_name: str = 'localization',
+                 odom_link_name: str = 'odom',
+                 drive_joint_name: str = 'brumbrum'):
+        self.map_name = map_name
+        self.localization_joint_name = localization_joint_name
+        self.odom_link_name = odom_link_name
+        self.drive_joint_name = drive_joint_name
+
+    def setup(self):
+        self.sync_6dof_joint_with_tf_frame(joint_name=self.localization_joint_name,
+                                           tf_parent_frame=self.map_name,
+                                           tf_child_frame=self.odom_link_name)
+        self.sync_joint_state_topic('/joint_states')
+        self.sync_odometry_topic('/odom', self.drive_joint_name)
+        fill_velocity_values = False
+        self.add_follow_joint_trajectory_server(namespace='/stretch_controller',
+                                                fill_velocity_values=fill_velocity_values,
+                                                goal_time_tolerance=100,
+                                                controlled_joints=['joint_gripper_finger_left',
+                                                                   'joint_lift',
+                                                                   'joint_arm_l3',
+                                                                   'joint_arm_l2',
+                                                                   'joint_arm_l1',
+                                                                   'joint_arm_l0',
+                                                                   'joint_wrist_yaw',
+                                                                   'joint_wrist_pitch',
+                                                                   'joint_wrist_roll',
+                                                                   'joint_head_pan',
+                                                                   'joint_head_tilt'])
+
+        self.add_base_cmd_velocity(cmd_vel_topic='/stretch/cmd_vel',
+                                   track_only_velocity=True,
+                                   joint_name=self.drive_joint_name)

--- a/src/giskardpy_ros/configs/robot_interface_config.py
+++ b/src/giskardpy_ros/configs/robot_interface_config.py
@@ -96,7 +96,8 @@ class RobotInterfaceConfig(ABC):
                                                                               joint_name=joint_name)
         elif GiskardBlackboard().tree.is_open_loop():
             self.tree.execute_traj.add_base_traj_action_server(cmd_vel_topic=cmd_vel_topic,
-                                                               joint_name=joint_name)
+                                                               joint_name=joint_name,
+                                                               track_only_velocity=track_only_velocity)
 
     def register_controlled_joints(self, joint_names: List[str], group_name: Optional[str] = None):
         """
@@ -113,7 +114,10 @@ class RobotInterfaceConfig(ABC):
                                            namespace: str,
                                            group_name: Optional[str] = None,
                                            fill_velocity_values: bool = False,
-                                           path_tolerance: Dict[Derivatives, float] = None):
+                                           path_tolerance: Dict[Derivatives, float] = None,
+                                           controlled_joints: List[str] = None,
+                                           goal_time_tolerance: float = 1
+                                           ):
         """
         Connect Giskard to a follow joint trajectory server. It will automatically figure out which joints are offered
         and can be controlled.
@@ -128,7 +132,9 @@ class RobotInterfaceConfig(ABC):
         self.tree.execute_traj.add_follow_joint_traj_action_server(namespace=namespace,
                                                                    group_name=group_name,
                                                                    fill_velocity_values=fill_velocity_values,
-                                                                   path_tolerance=path_tolerance)
+                                                                   path_tolerance=path_tolerance,
+                                                                   controlled_joints=controlled_joints,
+                                                                   goal_time_tolerance=goal_time_tolerance)
 
     def add_joint_velocity_controller(self, namespaces: List[str]):
         """

--- a/src/giskardpy_ros/tree/behaviors/send_trajectory.py
+++ b/src/giskardpy_ros/tree/behaviors/send_trajectory.py
@@ -64,7 +64,6 @@ class SendFollowJointTrajectory(ActionClient, GiskardBehavior):
         self.goal_time_tolerance = rospy.Duration(goal_time_tolerance)
         self.path_tolerance = path_tolerance
 
-        params: Dict[str, Any] = rospy.get_param(self.namespace)
         if not controlled_joints:
             params: Dict[str, Any] = rospy.get_param(self.namespace)
             controlled_joint_names = [PrefixName(j, self.group_name) for j in params['joints']]

--- a/src/giskardpy_ros/tree/behaviors/send_trajectory.py
+++ b/src/giskardpy_ros/tree/behaviors/send_trajectory.py
@@ -51,7 +51,8 @@ class SendFollowJointTrajectory(ActionClient, GiskardBehavior):
     @profile
     def __init__(self, namespace: str, group_name: str,
                  goal_time_tolerance: float = 1, fill_velocity_values: bool = True,
-                 path_tolerance: Dict[Derivatives, float] = None):
+                 path_tolerance: Dict[Derivatives, float] = None,
+                 controlled_joints: List[str]=None):
         self.group_name = group_name
         self.namespace = namespace
         self.action_namespace = f'{self.namespace}/follow_joint_trajectory'
@@ -64,13 +65,17 @@ class SendFollowJointTrajectory(ActionClient, GiskardBehavior):
         self.path_tolerance = path_tolerance
 
         params: Dict[str, Any] = rospy.get_param(self.namespace)
+        if not controlled_joints:
+            params: Dict[str, Any] = rospy.get_param(self.namespace)
+            controlled_joint_names = [PrefixName(j, self.group_name) for j in params['joints']]
+        else:
+            controlled_joint_names = [PrefixName(j, self.group_name) for j in controlled_joints]
 
         actual_type = wait_for_topic_to_appear(self.action_namespace + '/goal', self.supported_action_types)
         action_type = eval(actual_type._type.replace('/', '.msg.')[:-4])
 
         ActionClient.__init__(self, str(self), action_type, None, self.action_namespace)
 
-        controlled_joint_names = [PrefixName(j, self.group_name) for j in params['joints']]
         if len(controlled_joint_names) == 0:
             raise ValueError(f'\'{self.action_namespace}\' has no joints')
 
@@ -186,8 +191,8 @@ class SendFollowJointTrajectory(ActionClient, GiskardBehavior):
             if current_time.to_sec() < self.min_deadline.to_sec():
                 msg = f'\'{self.namespace}\' executed too quickly, stopping execution.'
                 e = ExecutionSucceededPrematurely(msg)
-                raise_to_blackboard(e)
-                return py_trees.Status.FAILURE
+                #raise_to_blackboard(e)
+                return py_trees.Status.RUNNING
             self.feedback_message = "goal reached"
             get_middleware().loginfo(f'\'{self.namespace}\' successfully executed the trajectory.')
             return py_trees.Status.SUCCESS

--- a/src/giskardpy_ros/tree/branches/send_controls.py
+++ b/src/giskardpy_ros/tree/branches/send_controls.py
@@ -21,5 +21,5 @@ class SendControls(RunningSelector):
     def add_joint_velocity_group_controllers(self, namespace: str):
         self.add_child(JointGroupVelController(namespace))
 
-    def add_send_cmd_velocity(self, cmd_vel_topic: str, joint_name: PrefixName = None):
-        self.add_child(SendCmdVel(cmd_vel_topic, joint_name=joint_name))
+    def add_send_cmd_velocity(self, cmd_vel_topic: str, joint_name: PrefixName = None, track_only_velocity: bool=False):
+        self.add_child(SendCmdVel(cmd_vel_topic, joint_name=joint_name, track_only_velocity=track_only_velocity))

--- a/src/giskardpy_ros/tree/branches/send_trajectories.py
+++ b/src/giskardpy_ros/tree/branches/send_trajectories.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 from py_trees import Sequence
 
@@ -23,9 +23,14 @@ class ExecuteTraj(Sequence):
 
     def add_follow_joint_traj_action_server(self, namespace: str, group_name: str,
                                             fill_velocity_values: bool,
-                                            path_tolerance: Dict[Derivatives, float] = None):
+                                            path_tolerance: Dict[Derivatives, float] = None,
+                                            controlled_joints: List[str] = None,
+                                            goal_time_tolerance: float = 1
+                                            ):
         behavior = SendFollowJointTrajectory(namespace=namespace, group_name=group_name,
-                                             fill_velocity_values=fill_velocity_values, path_tolerance=path_tolerance)
+                                             fill_velocity_values=fill_velocity_values, path_tolerance=path_tolerance,
+                                             controlled_joints=controlled_joints, goal_time_tolerance=goal_time_tolerance
+                                             )
         self.move_robots.add_child(behavior)
 
     def add_base_traj_action_server(self, cmd_vel_topic: str, track_only_velocity: bool = False,
@@ -37,4 +42,5 @@ class ExecuteTraj(Sequence):
             self.base_closed_loop.add_closed_loop_behaviors()
             self.move_robots.add_child(self.base_closed_loop)
         self.base_closed_loop.send_controls.add_send_cmd_velocity(cmd_vel_topic=cmd_vel_topic,
-                                                                  joint_name=joint_name)
+                                                                  joint_name=joint_name,
+                                                                  track_only_velocity=track_only_velocity)


### PR DESCRIPTION
added config for the stretch. For the stretch the controlled joints have to be specified manually in send_trajectory.py.
Please also have a look at the changed return statement in send_trajectory.py, can this be critical to other robots? For the stretch this was necessary for the communication with its controller, but we could try to change it back.