### PR TITLE
Fixed issue for Tiago-Tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ lxml>=4.5.0
 sortedcontainers>=2.4.0
 qpalm>=1.1.4
 PyQt5~=5.14.1
-pycollada>=0.7.2
+pycollada>=0.7.2,<0.9.1


### PR DESCRIPTION
pycollada version <0.9.1, because of compatibility issues with Python3.8 in Tiago-Tests.

See: https://github.com/SemRoCo/giskardpy_ros/actions/runs/16519995957