### PR TITLE
suggested fix

### DIFF
--- a/giskardpy_ros/configs/behavior_tree_config.py
+++ b/giskardpy_ros/configs/behavior_tree_config.py
@@ -275,6 +275,7 @@ class StandAloneBTConfig(BehaviorTreeConfig):
         if self.publish_robot_description:
             self.add_robot_description_publisher()
         self.add_evaluate_debug_expressions()
+        self._add_debug_trajectory_plotter()
         if self.publish_js:
             self.add_js_publisher(include_prefix=self.include_prefix)
         if self.publish_free_variables:

--- a/giskardpy_ros/tree/behaviors/plot_debug_expressions.py
+++ b/giskardpy_ros/tree/behaviors/plot_debug_expressions.py
@@ -50,7 +50,7 @@ class PlotDebugExpressions(PlotTrajectory):
 
     def plot(self):
         trajectory = god_map.debug_expression_manager.raw_traj_to_traj(
-            god_map.qp_controller.config.control_dt
+            god_map.qp_controller.config.control_dt or god_map.qp_controller.config.mpc_dt
         )
         if trajectory and len(trajectory) > 0:
             sample_period = god_map.qp_controller.config.mpc_dt
@@ -66,3 +66,7 @@ class PlotDebugExpressions(PlotTrajectory):
             except Exception:
                 traceback.print_exc()
                 get_middleware().logwarn("failed to save debug.pdf")
+            finally:
+                # Cancel timer so it only runs once
+                self.plot_thread.cancel()
+                self.plot_done = True

--- a/giskardpy_ros/tree/behaviors/plot_trajectory.py
+++ b/giskardpy_ros/tree/behaviors/plot_trajectory.py
@@ -3,16 +3,19 @@ from threading import Thread
 
 from line_profiler import profile
 from py_trees.common import Status
+from rclpy.executors import MultiThreadedExecutor
 
 from giskardpy.god_map import god_map
 from giskardpy.middleware import get_middleware
+from giskardpy_ros.ros2 import rospy
 from giskardpy_ros.tree.behaviors.plugin import GiskardBehavior
 from giskardpy.utils.decorators import record_time
 from line_profiler import profile
 
 
 class PlotTrajectory(GiskardBehavior):
-    plot_thread: Thread
+    plot_thread = None
+    plot_done = False
 
 
     def __init__(self, name, wait=False, joint_filter=None, normalize_position: bool = False, **kwargs):
@@ -24,8 +27,9 @@ class PlotTrajectory(GiskardBehavior):
 
 
     def initialise(self):
-        self.plot_thread = Thread(target=self.plot, name=self.name)
-        self.plot_thread.start()
+        # self.plot_thread = Thread(target=self.plot, name=self.name)
+        # self.plot_thread.start()
+        self.plot_thread = rospy.node.create_timer(0.0, self.plot)
 
     def plot(self):
         trajectory = god_map.trajectory
@@ -44,6 +48,6 @@ class PlotTrajectory(GiskardBehavior):
     @record_time
     
     def update(self):
-        if self.wait and self.plot_thread.is_alive():
+        if self.wait and not self.plot_done:
             return Status.RUNNING
         return Status.SUCCESS


### PR DESCRIPTION
The original solution to call plot() with a Thread seemed to have an issue because inside of the Thread some ros object was touched which is not allowed (quote ChatGPT)
A suggestion is to use the rospy.node.create_timer() instead to run the plot function. This works for me, but might not be the best solution.
When running from a test the test succeeds but afterwards this error is printed
```bash
  File "/home/huerkamp/workspace/ros/src/giskardpy_ros/giskardpy_ros/tree/behaviors/plot_debug_expressions.py", line 59, in plot
    traj.plot_trajectory(
  File "/home/huerkamp/libs/giskardpy/giskardpy/model/trajectory.py", line 251, in plot_trajectory
    get_middleware().loginfo(f"saved {file_name}")
  File "/home/huerkamp/workspace/ros/src/giskardpy_ros/giskardpy_ros/ros2/rospy.py", line 23, in loginfo
    node.get_logger().info(msg)
    ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_logger'
The following exception was never retrieved: cannot use Destroyable because destruction was requested
```

Also I had to use `god_map.qp_controller.config.control_dt or god_map.qp_controller.config.mpc_dt` as an argument for the raw_traj_to_traj() function, as in the test cases control_dt is None