### PR TITLE
prototyped fetch_world world config

### DIFF
--- a/giskardpy_ros/configs/fetch_world_config.py
+++ b/giskardpy_ros/configs/fetch_world_config.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from giskardpy.model.world_config import WorldConfig
+from semantic_digital_twin.robots.abstract_robot import AbstractRobot
+from semantic_digital_twin.world import World
+
+@dataclass
+class WorldWithFetchedRobot(WorldConfig):
+    robot_world: World = None
+    robot_class: type[AbstractRobot] = None  # 👈 Type hint: expects a class, not instance
+    robot: AbstractRobot = field(init=False, default=None)
+
+    def setup_collision_config(self):
+        pass
+
+    def setup_world(self):
+        super().setup_world()
+        self.world.merge_world(self.robot_world)
+        self.robot = self.robot_class.from_world(self.world)

--- a/giskardpy_ros/configs/fetch_world_config.py
+++ b/giskardpy_ros/configs/fetch_world_config.py
@@ -6,7 +6,7 @@ from semantic_digital_twin.world import World
 @dataclass
 class WorldWithFetchedRobot(WorldConfig):
     robot_world: World = None
-    robot_class: type[AbstractRobot] = None  # 👈 Type hint: expects a class, not instance
+    robot_class: type[AbstractRobot] = None
     robot: AbstractRobot = field(init=False, default=None)
 
     def setup_collision_config(self):

--- a/giskardpy_ros/ros2/msg_converter.py
+++ b/giskardpy_ros/ros2/msg_converter.py
@@ -52,7 +52,7 @@ from semantic_digital_twin.world_description.geometry import (
     Sphere,
     Mesh,
     Color,
-    Scale,
+    Scale, TriangleMesh,
 )
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.spatial_types.derivatives import Derivatives
@@ -161,7 +161,10 @@ def link_geometry_mesh_to_visualization_marker(
     if mode.is_collision_decomposed():
         marker.mesh_resource = "file://" + data.collision_file_name_absolute
     else:
-        marker.mesh_resource = "file://" + data.filename
+        if type(data) == TriangleMesh:
+            marker.mesh_resource = "file://" + data.file.name
+        else:
+            marker.mesh_resource = "file://" + data.filename
     marker.scale.x = data.scale.x
     marker.scale.y = data.scale.y
     marker.scale.z = data.scale.z


### PR DESCRIPTION
This PR suggest how the giskard world config could be used to fetch an already existing world.
1. The `WorldWithFetchedRobot` class accepts a world object as parameter and merges it into giskards existing world. This way the script that initializes giskard can fetch a world using the semDT functionalities and pass it to the config class. At the moment fetching cannot be made in the `WorldWithFetchedRobot` class, as the `setup_world()` function is called inside a `with world.modify_world()` block.
2. The `WorldWithFetchedRobot` class accepts `robot_class` parameter to specify from the initialization script from which class the robot view should be created. This is kinda ugly, but for me the `merge_world()` function did not work when a robot view already existed. This might be fixed in the future and robot views might already exist in the merged world
3. changes in `msg_converter.py`: It seems that fetching a world replaces FileMesh with TriangleMesh which holds a "tmp/tmp/something" file name which has to be accessed with `.file.name` instead of `.filename`. This function would need more refactoring to consider this in all visualization modes. This hints that more changes might be needed for working with fetched worlds.
