### PR TITLE
Adjusted interactive_marker Node parameters

### DIFF
--- a/launch/giskardpy_hsr_standalone.launch.py
+++ b/launch/giskardpy_hsr_standalone.launch.py
@@ -8,10 +8,16 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+
 
 def generate_launch_description():
     robot_description = Command(
@@ -27,28 +33,37 @@ def generate_launch_description():
             ),
         ]
     )
-    return LaunchDescription([
-        Node(
-            package='giskardpy_ros',
-            executable='hsr_standalone',
-            name='giskard',
-            parameters=[{'robot_description': robot_description}],
-            output='screen',
-        ),
-        Node(
-            package='giskardpy_ros',
-            executable='interactive_marker',
-            name='giskard_interactive_marker',
-            parameters=[{'root_link': 'map',
-                         'tip_link': 'hand_gripper_tool_frame'}],
-            output='screen',
-        ),
-        # RViz node
-        Node(
-            package='rviz2',
-            executable='rviz2',
-            name='rviz2',
-            output='screen',
-        ),
-    ])
-
+    return LaunchDescription(
+        [
+            Node(
+                package="giskardpy_ros",
+                executable="hsr_standalone",
+                name="giskard",
+                parameters=[{"robot_description": robot_description}],
+                output="screen",
+            ),
+            Node(
+                package="giskardpy_ros",
+                executable="interactive_marker",
+                name="giskard_interactive_marker",
+                parameters=[
+                    {
+                        "root_links": ["map", "map", "map"],
+                        "tip_links": [
+                            "hand_palm_link",
+                            "base_footprint",
+                            "head_rgbd_sensor_link",
+                        ],
+                    },
+                ],
+                output="screen",
+            ),
+            # RViz node
+            Node(
+                package="rviz2",
+                executable="rviz2",
+                name="rviz2",
+                output="screen",
+            ),
+        ]
+    )

--- a/launch/giskardpy_hsr_velocity.launch.py
+++ b/launch/giskardpy_hsr_velocity.launch.py
@@ -49,8 +49,14 @@ def generate_launch_description():
                 executable="interactive_marker",
                 name="giskard_interactive_marker",
                 parameters=[
-                    {"root_link": "map", "tip_link": "hand_palm_link"},
-                    # {"root_link": "map", "tip_link": "base_link"},
+                    {
+                        "root_links": ["map", "map", "map"],
+                        "tip_links": [
+                            "hand_palm_link",
+                            "base_footprint",
+                            "head_rgbd_sensor_link",
+                        ],
+                    },
                 ],
                 output="screen",
             ),

--- a/launch/giskardpy_hsr_velocity_trust_me_bro.launch.py
+++ b/launch/giskardpy_hsr_velocity_trust_me_bro.launch.py
@@ -49,8 +49,14 @@ def generate_launch_description():
                 executable="interactive_marker",
                 name="giskard_interactive_marker",
                 parameters=[
-                    {"root_link": "map", "tip_link": "hand_palm_link"},
-                    # {"root_link": "map", "tip_link": "base_link"},
+                    {
+                        "root_links": ["map", "map", "map"],
+                        "tip_links": [
+                            "hand_palm_link",
+                            "base_footprint",
+                            "head_rgbd_sensor_link",
+                        ],
+                    },
                 ],
                 output="screen",
             ),

--- a/launch/giskardpy_pr2_standalone.launch.py
+++ b/launch/giskardpy_pr2_standalone.launch.py
@@ -59,7 +59,17 @@ def generate_launch_description():
                 package="giskardpy_ros",
                 executable="interactive_marker",
                 name="giskard_interactive_marker",
-                parameters=[{"root_link": "map", "tip_link": "r_gripper_tool_frame"}],
+                parameters=[
+                    {
+                        "root_links": ["map", "map", "map", "map"],
+                        "tip_links": [
+                            "r_gripper_tool_frame",
+                            "l_gripper_tool_frame",
+                            "base_footprint",
+                            "high_def_frame",
+                        ],
+                    }
+                ],
                 output="screen",
             ),
         ]

--- a/launch/giskardpy_tracy_standalone.launch.py
+++ b/launch/giskardpy_tracy_standalone.launch.py
@@ -8,50 +8,61 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
+
 def generate_launch_description():
-    tracy_xacro_file = os.path.join(get_package_share_directory('iai_tracy_description'), 'urdf',
-                                    'tracy.urdf.xacro')
-    robot_description = Command(
-        [FindExecutable(name='xacro'), ' ', tracy_xacro_file])
+    tracy_xacro_file = os.path.join(
+        get_package_share_directory("iai_tracy_description"), "urdf", "tracy.urdf.xacro"
+    )
+    robot_description = Command([FindExecutable(name="xacro"), " ", tracy_xacro_file])
 
-    return LaunchDescription([
-        # Static transform publisher (example, modify as needed for your robot)
-        #IncludeLaunchDescription(
-        #    PythonLaunchDescriptionSource(upload_pr2_launch)
-        #),
-        Node(
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            name='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'map', 'world']
-        ),
-        Node(
-            package='giskardpy_ros',
-            executable='tracy_standalone',
-            name='giskard',
-            parameters=[{'robot_description': robot_description}],
-            output='screen',
-        ),
-        Node(
-            package='giskardpy_ros',
-            executable='interactive_marker',
-            name='giskard_interactive_marker',
-            parameters=[{'root_link': 'map',
-                         'tip_link': 'l_gripper_tool_frame'}],
-            output='screen',
-        ),
-        # RViz node
-        Node(
-            package='rviz2',
-            executable='rviz2',
-            name='rviz2',
-            output='screen',
-        ),
-    ])
-
+    return LaunchDescription(
+        [
+            # Static transform publisher (example, modify as needed for your robot)
+            # IncludeLaunchDescription(
+            #    PythonLaunchDescriptionSource(upload_pr2_launch)
+            # ),
+            Node(
+                package="tf2_ros",
+                executable="static_transform_publisher",
+                name="static_transform_publisher",
+                output="screen",
+                arguments=["0", "0", "0", "0", "0", "0", "map", "world"],
+            ),
+            Node(
+                package="giskardpy_ros",
+                executable="tracy_standalone",
+                name="giskard",
+                parameters=[{"robot_description": robot_description}],
+                output="screen",
+            ),
+            Node(
+                package="giskardpy_ros",
+                executable="interactive_marker",
+                name="giskard_interactive_marker",
+                parameters=[
+                    {
+                        "root_links": ["map", "map"],
+                        "tip_links": ["l_gripper_tool_frame", "r_gripper_tool_frame"],
+                    }
+                ],
+                output="screen",
+            ),
+            # RViz node
+            Node(
+                package="rviz2",
+                executable="rviz2",
+                name="rviz2",
+                output="screen",
+            ),
+        ]
+    )

--- a/launch/giskardpy_tracy_velocity.launch.py
+++ b/launch/giskardpy_tracy_velocity.launch.py
@@ -8,51 +8,61 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
+
 def generate_launch_description():
-    tracy_xacro_file = os.path.join(get_package_share_directory('iai_tracy_description'), 'urdf',
-                                    'tracy.urdf.xacro')
-    robot_description = Command(
-        [FindExecutable(name='xacro'), ' ', tracy_xacro_file])
+    tracy_xacro_file = os.path.join(
+        get_package_share_directory("iai_tracy_description"), "urdf", "tracy.urdf.xacro"
+    )
+    robot_description = Command([FindExecutable(name="xacro"), " ", tracy_xacro_file])
 
-    return LaunchDescription([
-        # Static transform publisher (example, modify as needed for your robot)
-        #IncludeLaunchDescription(
-        #    PythonLaunchDescriptionSource(upload_pr2_launch)
-        #),
-        Node(
-            package='rviz2',
-            executable='rviz2',
-            name='rviz2',
-            output='screen',
-        ),
-        Node(
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            name='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'map', 'world']
-        ),
-        Node(
-            package='giskardpy_ros',
-            executable='tracy_velocity',
-            name='giskard',
-            parameters=[{'robot_description': robot_description}],
-            output='screen',
-        ),
-        Node(
-            package='giskardpy_ros',
-            executable='interactive_marker',
-            name='giskard_interactive_marker',
-            parameters=[{'root_link': 'map',
-                         'tip_link': 'l_gripper_tool_frame'}],
-            output='screen',
-        ),
-        # RViz node
-
-    ])
-
+    return LaunchDescription(
+        [
+            # Static transform publisher (example, modify as needed for your robot)
+            # IncludeLaunchDescription(
+            #    PythonLaunchDescriptionSource(upload_pr2_launch)
+            # ),
+            Node(
+                package="rviz2",
+                executable="rviz2",
+                name="rviz2",
+                output="screen",
+            ),
+            Node(
+                package="tf2_ros",
+                executable="static_transform_publisher",
+                name="static_transform_publisher",
+                output="screen",
+                arguments=["0", "0", "0", "0", "0", "0", "map", "world"],
+            ),
+            Node(
+                package="giskardpy_ros",
+                executable="tracy_velocity",
+                name="giskard",
+                parameters=[{"robot_description": robot_description}],
+                output="screen",
+            ),
+            Node(
+                package="giskardpy_ros",
+                executable="interactive_marker",
+                name="giskard_interactive_marker",
+                parameters=[
+                    {
+                        "root_links": ["map", "map"],
+                        "tip_links": ["l_gripper_tool_frame", "r_gripper_tool_frame"],
+                    }
+                ],
+                output="screen",
+            ),
+            # RViz node
+        ]
+    )

--- a/launch/r6bot_velocity.launch.py
+++ b/launch/r6bot_velocity.launch.py
@@ -33,8 +33,10 @@ def generate_launch_description():
                 executable="interactive_marker",
                 name="giskard_interactive_marker",
                 parameters=[
-                    {"root_link": "base_link", "tip_link": "tool0"},
-                    # {"root_link": "map", "tip_link": "base_link"},
+                    {
+                        "root_links": ["base_link", "map"],
+                        "tip_links": ["tool0", "base_link"],
+                    },
                 ],
                 output="screen",
             ),

--- a/launch/stretch_velocity.launch.py
+++ b/launch/stretch_velocity.launch.py
@@ -35,8 +35,10 @@ def generate_launch_description():
                 executable="interactive_marker",
                 name="giskard_interactive_marker",
                 parameters=[
-                    {"root_link": "link_straight_gripper", "tip_link": "link_gripper_fingertip_left"},
-                    # {"root_link": "map", "tip_link": "base_link"},
+                    {
+                        "root_links": ["link_straight_gripper", "map"],
+                        "tip_links": ["link_gripper_fingertip_left", "base_link"],
+                    },
                 ],
                 output="screen",
             ),


### PR DESCRIPTION
Multiple interactive markers can now be created again.
Had to change the parameter name and syntax to enable this.
Now uses STRING_ARRAY for root_links and tip_links to match them in order for every individual interactive marker.
Also added the previously used interactive markers back to the launch files.